### PR TITLE
Message sending via Discord Webhooks

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ const defaultConfig = {
     },
     matrix: {
         serverURL: "https://matrix.org",
+        accessURL: "https://matrix.org",
         domain: "matrix.org",
         bridgeAccount: {
             userId: "@example:matrix.org",
@@ -45,6 +46,7 @@ export interface DiscordConfig {
 
 export interface MatrixConfig {
     serverURL: string;
+    accessURL: string;
     domain: string;
     bridgeAccount: { userId: string, password: string };
 }

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -162,15 +162,9 @@ export class DiscordBot {
                             fs.unlinkSync(downloadedLocation); // Remove the temporary avatar file we downloaded
 
                             userIntent.setAvatarUrl(url).then(() => {
-                                let newUser = new RemoteUser(member.user.id);
+                                user.set("avatar", member.user.avatar);
 
-                                newUser.set("avatar", member.user.avatar);
-                                newUser.set("rooms", user.data.rooms);
-                                newUser.set("name", name);
-
-                                userStore.delete({id: member.user.id }).then(() => {
-                                    userStore.setRemoteUser(newUser);
-                                });
+                                userStore.setRemoteUser(user);
                             });
                         });
                     });
@@ -182,15 +176,7 @@ export class DiscordBot {
                         userIntent.join(remoteRoomEntry.matrix.roomId).then(() => {
                             user.data.rooms.push(remoteRoomEntry.remote.get("channel"));
 
-                            let newUser = new RemoteUser(member.user.id);
-
-                            newUser.set("avatar", member.user.avatar);
-                            newUser.set("rooms", user.data.rooms);
-                            newUser.set("name", name);
-
-                            userStore.delete({id: member.user.id }).then(() => {
-                                userStore.setRemoteUser(newUser);
-                            });
+                            userStore.setRemoteUser(user);
                         });
                     });
                 }
@@ -198,15 +184,9 @@ export class DiscordBot {
                 // Set our display name if it's changed
                 if(user.data.name != name) {
                     userIntent.setDisplayName(name + (member.user.bot ? " [BOT]" : "") + " (Discord)").then(() => {
-                        let newUser = new RemoteUser(member.user.id);
+                        user.set("name", name);
 
-                        newUser.set("avatar", member.user.avatar);
-                        newUser.set("rooms", user.data.rooms);
-                        newUser.set("name", name);
-
-                        userStore.delete({id: member.user.id }).then(() => {
-                            userStore.setRemoteUser(newUser);
-                        });
+                        userStore.setRemoteUser(user);
                     });
                 }
             } else {

--- a/src/discordEventHandler.ts
+++ b/src/discordEventHandler.ts
@@ -47,6 +47,8 @@ export class DiscordEventHandler {
     public onMessage(message: Discord.Message) {
         // We don't want echo from our bot (eg. sending messages to matrix that are from our own bot on discord)
         if(message.author.username == this.discordBot.getBridge().config.discord.username) return;
+        // We don't want echo from our webhook bots
+        if(message.webhookID) return;
 
         let discordBot = this.discordBot;
         let intent = discordBot.getBridge().matrixAppservice.getIntentForUser(message.author.id);

--- a/src/discordEventHandler.ts
+++ b/src/discordEventHandler.ts
@@ -36,6 +36,30 @@ export class DiscordEventHandler {
             let roomNumber = channel.id.substr(channel.id.length - 4);
             let domain = this.discordBot.getBridge().config.matrix.domain;
 
+            // Delete the old webhooks for this channel from the database
+            this.discordBot.getBridge().matrixAppservice.matrixBridge.getUserStore().getByMatrixData({
+                webhookUser: true
+            }).then((users: Array<any>) => {
+                users.forEach((user) => {
+                    let userWebhooks = user.get("webhooks");
+                    console.log("Found user: " + user.getDisplayName());
+
+                    if(userWebhooks && Object.keys(userWebhooks).length > 0) { // Check if webhooks dictionary is empty or not
+                        console.log("Not empty")
+                        if(userWebhooks[channel.id]) { // check if there is a webhook for the to-be-deleted channel
+                            console.log("Found webhook");
+                            delete userWebhooks[channel.id]; // Remove that webhook entry for that channel
+
+                            console.log("Deleted");
+
+                            this.discordBot.getBridge().matrixAppservice.matrixBridge.getUserStore().setMatrixUser(user).then(() => {
+                                console.log("deleted");
+                            });
+                        }
+                    }
+                });
+            });
+
             this.discordBot.handleChannelDelete(roomNumber, channel.name, channel.id);
         }
     }

--- a/src/matrixEventHandler.ts
+++ b/src/matrixEventHandler.ts
@@ -15,6 +15,10 @@ export class MatrixEventHandler {
     public onRoomMemberEvent(request, context) {
         let event = request.getData();
 
+        // We don't want echo from our own bots or appservice
+        if(event.state_key.startsWith("@" + appserviceUserPart)) return;
+        if(event.state_key.startsWith("@!discord_")) return;
+
         let roomStore = this.matrix.matrixBridge.getRoomStore();
         let userStore = this.matrix.matrixBridge.getUserStore();
         let intent = this.matrix.matrixBridge.getIntent();
@@ -29,6 +33,7 @@ export class MatrixEventHandler {
                         console.log("Inserting new Matrix User");
                         let matrixUser = new MatrixUser(event.state_key);
                         matrixUser.set("webhooks", {});
+                        matrixUser.set("webhookUser", true);
                         matrixUser.set("avatarURL", event.content.avatar_url);
                         matrixUser.setDisplayName(event.content.displayname);
 
@@ -37,9 +42,6 @@ export class MatrixEventHandler {
                 });
             case "leave":
             case "ban":
-                if(event.state_key.startsWith("@" + appserviceUserPart)) return;
-                if(event.state_key.startsWith("@!discord_")) return;
-
                 roomStore.getEntriesByMatrixId(event.room_id).then((entries) => {
                     if(entries.length > 0) {
                         let entry = entries[0];
@@ -100,6 +102,30 @@ export class MatrixEventHandler {
     }
 
     private handleMissingChannelMapping(entry, channelId, channelName) {
+        // Delete the old webhooks for this channel from the database
+        this.matrix.matrixBridge.getUserStore().getByMatrixData({
+            webhookUser: true
+        }).then((users: Array<any>) => {
+            users.forEach((user) => {
+                let userWebhooks = user.get("webhooks");
+                console.log("Found user: " + user.getDisplayName());
+
+                if(userWebhooks && Object.keys(userWebhooks).length > 0) { // Check if webhooks dictionary is empty or not
+                    console.log("Not empty")
+                    if(userWebhooks[channelId]) { // check if there is a webhook for the to-be-deleted channel
+                        console.log("Found webhook");
+                        delete userWebhooks[channelId]; // Remove that webhook entry for that channel
+
+                        console.log("Deleted");
+
+                        this.matrix.matrixBridge.getUserStore().setMatrixUser(user).then(() => {
+                            console.log("deleted");
+                        });
+                    }
+                }
+            });
+        });
+
         this.matrix.getBridge().discordBot.handleChannelDelete(channelId.substr(channelId.length - 4), channelName, channelId);
     }
 }

--- a/src/messageHandling.ts
+++ b/src/messageHandling.ts
@@ -5,6 +5,7 @@ import * as matrix from "./matrix";
 
 import * as util from "./util";
 
+import { DiscordMatrixBridge } from "./main";
 import { DiscordBot } from "./discord";
 import { MatrixAppservice } from "./matrix";
 
@@ -103,41 +104,91 @@ export function processDiscordToMatrixMessage(message: Discord.Message, discordB
     }
 }
 
-export function processMatrixToDiscordMessage(event, channel: Discord.TextChannel, serverURL: string) {
+let webhookCreationLock = {};
+
+export function processMatrixToDiscordMessage(event, channel: Discord.TextChannel, serverURL: string, appservice: MatrixAppservice) {
     let sentMessage: string;
 
-    switch(event.content.msgtype) {
-        case "m.text":
-            channel.send("**" + event.sender + "**: " + event.content.body);
-            return;
-
-        case "m.file":
-            sentMessage = "sent a file: ";
-            break;
-        case "m.image":
-            sentMessage = "sent an image: ";
-            break;
-        case "m.video":
-            sentMessage = "sent a video: ";
-            break;
-        case "m.audio":
-            sentMessage = "sent an audio file: ";
-            break;
-
-        default:
-            return;
+    if(webhookCreationLock[event.sender]) {
+        setTimeout(function() {
+            processMatrixToDiscordMessage(event, channel, serverURL, appservice);
+        }, 200);
+        return;
     }
 
-    let downloadURL = serverURL + "/_matrix/media/v1/download/" + event.content.url.replace("mxc://", "");
-    // Check if file size is greater than 8 MB, discord does not allow files greater than 8 MB
-    if(event.content.info.size >= (1024*1024*8)) {
-        // File is too big, send link then
-        channel.send("**" + event.sender + "**: ***" + sentMessage + "*** " + downloadURL);
-    } else {
-        util.download(downloadURL, event.content.body, (contentType, downloadedLocation) => {
-            channel.send("**" + event.sender + "**: ***" + sentMessage + "*** " + event.content.body, new Discord.Attachment(downloadedLocation, event.content.body))
-                .then(() => unlinkSync(downloadedLocation));
-                // Delete the image we downloaded after we uploaded it
+    getWebhook(event, channel, appservice.getBridge()).then((webhook) => {
+        switch(event.content.msgtype) {
+            case "m.text":
+                webhook.send("**" + event.sender + "**: " + event.content.body);
+                return;
+
+            case "m.file":
+                sentMessage = "sent a file: ";
+                break;
+            case "m.image":
+                sentMessage = "sent an image: ";
+                break;
+            case "m.video":
+                sentMessage = "sent a video: ";
+                break;
+            case "m.audio":
+                sentMessage = "sent an audio file: ";
+                break;
+
+            default:
+                return;
+        }
+
+        let downloadURL = util.getMXCDownloadURL(event.content.url, appservice.getBridge().config);
+        // Check if file size is greater than 8 MB, discord does not allow files greater than 8 MB
+        if(event.content.info.size >= (1024*1024*8)) {
+            // File is too big, send link then
+            webhook.send("**" + event.sender + "**: ***" + sentMessage + "*** " + downloadURL);
+        } else {
+            util.download(downloadURL, event.content.body, (contentType, downloadedLocation) => {
+                webhook.send("**" + event.sender + "**: ***" + sentMessage + "*** " + event.content.body, new Discord.Attachment(downloadedLocation, event.content.body))
+                    .then(() => unlinkSync(downloadedLocation));
+                    // Delete the image we downloaded after we uploaded it
+            });
+        }
+    });
+}
+
+function getWebhook(event, channel: Discord.TextChannel, bridge: DiscordMatrixBridge): Promise<Discord.Webhook> {
+    let userStore = bridge.matrixAppservice.matrixBridge.getUserStore();
+
+    if(!webhookCreationLock[event.sender]) {
+        webhookCreationLock[event.sender] = true;
+    }
+
+    return new Promise((resolve, reject) => {
+        userStore.getMatrixUser(event.sender).then((user) => {
+            let userWebhooks = user.get("webhooks");
+            if(!userWebhooks) {
+                userWebhooks = {};
+            }
+
+            if(Object.keys(userWebhooks).length > 0) { // Check if webhooks dictionary is empty or not
+                if(userWebhooks[channel.id]) { // check if there is already a webhook in here
+                    channel.fetchWebhooks().then((webhooks) => {
+                        webhookCreationLock[event.sender] = false;
+                        resolve(webhooks.get(userWebhooks[channel.id]));
+                    });
+                    return;
+                }
+            }
+
+            // No webhooks found
+
+            channel.createWebhook(event.sender, util.getMXCDownloadURL(user.get("avatarURL"), bridge.config)).then((webhook) => {
+                userWebhooks[channel.id] = webhook.id;
+                user.set("webhooks", userWebhooks);
+
+                userStore.setMatrixUser(user).then(() => {
+                    webhookCreationLock[event.sender] = false;
+                    resolve(webhook);
+                });
+            });
         });
-    }
+    });
 }

--- a/src/messageHandling.ts
+++ b/src/messageHandling.ts
@@ -180,7 +180,7 @@ function getWebhook(event, channel: Discord.TextChannel, bridge: DiscordMatrixBr
 
             // No webhooks found
 
-            channel.createWebhook(event.sender, util.getMXCDownloadURL(user.get("avatarURL"), bridge.config)).then((webhook) => {
+            channel.createWebhook(user.getDisplayName(), util.getMXCDownloadURL(user.get("avatarURL"), bridge.config)).then((webhook) => {
                 userWebhooks[channel.id] = webhook.id;
                 user.set("webhooks", userWebhooks);
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,6 +5,8 @@ import { tmpdir } from "os";
 import { join, extname } from "path";
 import { mkdirSync, createWriteStream } from "fs";
 
+import { BridgeConfig } from "./config";
+
 var tempDir = join(tmpdir(), "matrix-discord-bridge");
 
 try {
@@ -27,6 +29,11 @@ export function download(url: string, filename: string, callback: (contentType: 
 
         request(url).pipe(createWriteStream(downloadedLocation)).on('close', () => callback(contentType, downloadedLocation));
     });
+}
+
+export function getMXCDownloadURL(mxcURL: string, config: BridgeConfig): string {
+    let mxcURLClean = mxcURL.replace("mxc://", "");
+    return config.matrix.accessURL + "/_matrix/media/v1/download/" + mxcURLClean;
 }
 
 export function uploadMatrix(stream, filename: string, mimetype: string, client): Promise<string> {


### PR DESCRIPTION
To implement a similar system to Matrix's appservices, where BOT users can be created to represent discord users on matrix, webhooks can be used on Discord.

**Current pull is a drop in replacement for message sending via webhook, all features implemented correctly**

***However, some additonal checking is needed to make sure database does not fill up with garbage webhooks***